### PR TITLE
Fix missing RuntimeIdentifier

### DIFF
--- a/Git.hub.Demo/Git.hub.Demo.csproj
+++ b/Git.hub.Demo/Git.hub.Demo.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Git.hub.Demo</RootNamespace>
     <AssemblyName>Git.hub.Demo</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/Git.hub/Git.hub.csproj
+++ b/Git.hub/Git.hub.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Git.hub</RootNamespace>
     <AssemblyName>Git.hub</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>


### PR DESCRIPTION
It appears MSBuild 15.8 or 15.9 requires explicit RuntimeIdentifier=win.

Part of gitextensions/gitextensions#6497