### PR TITLE
Migrate code to latest RestSharp version

### DIFF
--- a/Git.hub/Client.cs
+++ b/Git.hub/Client.cs
@@ -151,7 +151,7 @@ namespace Git.hub
 
             var request = new RestRequest($"/users/{userName}");
 
-            var user = await _client.ExecuteGetTaskAsync<User>(request);
+            var user = await _client.ExecuteGetAsync<User>(request);
             return user.Data;
         }
 

--- a/Git.hub/OAuth2Helper.cs
+++ b/Git.hub/OAuth2Helper.cs
@@ -56,7 +56,7 @@ namespace Git.hub
 
         protected override Parameter GetAuthenticationParameter(string accessToken)
         {
-            return new Parameter("Authorization", "bearer " + Token, ParameterType.HttpHeader);
+            return new Parameter("Authorization", "bearer " + accessToken, ParameterType.HttpHeader);
         }
     }
 }

--- a/Git.hub/OAuth2Helper.cs
+++ b/Git.hub/OAuth2Helper.cs
@@ -50,13 +50,13 @@ namespace Git.hub
     /// (not even sure why) Using RestSharp's authenticators works on GET /user, but not GET /user/repos?
     /// This basically works around that.
     /// </summary>
-    class OAuth2AuthHelper : OAuth2Authenticator
+    class OAuth2AuthHelper : AuthenticatorBase
     {
         public OAuth2AuthHelper(string token) : base(token) { }
 
-        public override void Authenticate(IRestClient client, IRestRequest request)
+        protected override Parameter GetAuthenticationParameter(string accessToken)
         {
-            request.AddHeader("Authorization", "bearer " + AccessToken);
+            return new Parameter("Authorization", "bearer " + Token, ParameterType.HttpHeader);
         }
     }
 }


### PR DESCRIPTION
This PR is complementary to https://github.com/gitextensions/gitextensions/pull/8123

OAuth2Authenticator is obsolete now, rewriten to new AuthenticatorBase. I looked to RestSharp repo before and after and my change should be 1:1 as before. I tested this change in GitExtensions with "Plugins > GitHub" and created token successfully.

ExecuteGetTaskAsync was renamed to ExecuteGetAsync.