### PR TITLE
Remove GitUrl as git:// protocol is no more supported by GitHub

### DIFF
--- a/Git.hub/APIv2/RepositoryV2.cs
+++ b/Git.hub/APIv2/RepositoryV2.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using RestSharp;
 
 namespace Git.hub.APIv2
@@ -33,7 +30,6 @@ namespace Git.hub.APIv2
                 Forks = Forks,
                 Private = Private,
 
-                GitUrl = string.Format("git://github.com/{0}/{1}.git", Owner, Name),
                 SshUrl = string.Format("git@github.com:{0}/{1}.git", Owner, Name),
                 CloneUrl = string.Format("https://github.com/{0}/{1}.git", Owner, Name),
                 Detailed = false,

--- a/Git.hub/Repository.cs
+++ b/Git.hub/Repository.cs
@@ -33,12 +33,6 @@ namespace Git.hub
         }
 
         /// <summary>
-        /// Read-only clone url
-        /// git://github.com/{user}/{repo}.git
-        /// </summary>
-        public string GitUrl { get; internal set; }
-
-        /// <summary>
         /// Read/Write clone url via SSH
         /// git@github.com/{user}/{repo.git}
         /// </summary>


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective

Changes done by @pmiossec 